### PR TITLE
Apm truncate issue 112976

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/backend_link.tsx
+++ b/x-pack/plugins/apm/public/components/shared/backend_link.tsx
@@ -28,8 +28,7 @@ export function BackendLink({
   query,
   subtype,
   type,
-  onClick,
-  ...rest
+  onClick
 }: BackendLinkProps) {
   const { link } = useApmRouter();
 

--- a/x-pack/plugins/apm/public/components/shared/backend_link.tsx
+++ b/x-pack/plugins/apm/public/components/shared/backend_link.tsx
@@ -13,6 +13,7 @@ import { useApmRouter } from '../../hooks/use_apm_router';
 import { truncate } from '../../utils/style';
 import { ApmRoutes } from '../routing/apm_route_config';
 import { SpanIcon } from './span_icon';
+import { TruncateWithTooltip } from './truncate_with_tooltip';
 
 const StyledLink = euiStyled(EuiLink)`${truncate('100%')};`;
 
@@ -28,6 +29,7 @@ export function BackendLink({
   subtype,
   type,
   onClick,
+  ...rest
 }: BackendLinkProps) {
   const { link } = useApmRouter();
 
@@ -37,12 +39,14 @@ export function BackendLink({
         query,
       })}
       onClick={onClick}
-    >
+    > 
       <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
         <EuiFlexItem grow={false}>
           <SpanIcon type={type} subtype={subtype} />
         </EuiFlexItem>
-        <EuiFlexItem>{query.backendName}</EuiFlexItem>
+        <EuiFlexItem>
+          <TruncateWithTooltip text={query.backendName} content={query.backendName} />
+        </EuiFlexItem>
       </EuiFlexGroup>
     </StyledLink>
   );

--- a/x-pack/plugins/apm/public/components/shared/dependencies_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/dependencies_table/index.tsx
@@ -69,6 +69,7 @@ export function DependenciesTable(props: Props) {
       name: nameColumnTitle,
       render: (_, item) => {
         const { name, link: itemLink } = item;
+        itemLink.props.children = name;
         return <TruncateWithTooltip text={name} content={itemLink} />;
       },
       sortable: true,

--- a/x-pack/plugins/apm/public/components/shared/dependencies_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/dependencies_table/index.tsx
@@ -69,7 +69,6 @@ export function DependenciesTable(props: Props) {
       name: nameColumnTitle,
       render: (_, item) => {
         const { name, link: itemLink } = item;
-        itemLink.props.children = name;
         return <TruncateWithTooltip text={name} content={itemLink} />;
       },
       sortable: true,

--- a/x-pack/plugins/apm/public/components/shared/service_link.tsx
+++ b/x-pack/plugins/apm/public/components/shared/service_link.tsx
@@ -14,6 +14,7 @@ import { useApmRouter } from '../../hooks/use_apm_router';
 import { AgentIcon } from './agent_icon';
 import { AgentName } from '../../../typings/es_schemas/ui/fields/agent';
 import { ApmRoutes } from '../routing/apm_route_config';
+import { TruncateWithTooltip } from './truncate_with_tooltip';
 
 const StyledLink = euiStyled(EuiLink)`${truncate('100%')};`;
 
@@ -42,7 +43,9 @@ export function ServiceLink({
         <EuiFlexItem grow={false}>
           <AgentIcon agentName={agentName} />
         </EuiFlexItem>
-        <EuiFlexItem>{serviceName}</EuiFlexItem>
+        <EuiFlexItem>
+          <TruncateWithTooltip text={serviceName} content={serviceName} />
+        </EuiFlexItem>
       </EuiFlexGroup>
     </StyledLink>
   );


### PR DESCRIPTION
## Summary

This PR will resolve ellipsis truncation issue which is mentioned here. The following screenshots clearly show that the ellipsis has been applied on dependency and service name section.

elastic#112976

Dependencies section :

<img width="1440" alt="Screenshot 2021-12-28 at 2 28 39 PM" src="https://user-images.githubusercontent.com/24849645/147903781-ee73b1eb-3add-4955-bb14-778c3bc9349c.png">

Services section:

<img width="1440" alt="Screenshot 2021-12-28 at 2 28 27 PM" src="https://user-images.githubusercontent.com/24849645/147903813-67724f84-0f78-40a7-b692-bad7350af9a5.png">

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
