### PR TITLE
created a new component for truncation without tooltip

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/backend_link.tsx
+++ b/x-pack/plugins/apm/public/components/shared/backend_link.tsx
@@ -13,7 +13,7 @@ import { useApmRouter } from '../../hooks/use_apm_router';
 import { truncate } from '../../utils/style';
 import { ApmRoutes } from '../routing/apm_route_config';
 import { SpanIcon } from './span_icon';
-import { TruncateWithoutTooltip } from './truncate_with_tooltip';
+import { TruncateWithoutTooltip } from './truncate_without_tooltip';
 
 const StyledLink = euiStyled(EuiLink)`min-width: 0`;
 
@@ -38,7 +38,7 @@ export function BackendLink({
   query,
   subtype,
   type,
-  onClick
+  onClick,
 }: BackendLinkProps) {
   const { link } = useApmRouter();
 
@@ -48,7 +48,7 @@ export function BackendLink({
         query,
       })}
       onClick={onClick}
-    > 
+    >
       <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
         <EuiFlexItem grow={false}>
           <SpanIcon type={type} subtype={subtype} />

--- a/x-pack/plugins/apm/public/components/shared/service_link.tsx
+++ b/x-pack/plugins/apm/public/components/shared/service_link.tsx
@@ -14,7 +14,7 @@ import { useApmRouter } from '../../hooks/use_apm_router';
 import { AgentIcon } from './agent_icon';
 import { AgentName } from '../../../typings/es_schemas/ui/fields/agent';
 import { ApmRoutes } from '../routing/apm_route_config';
-import { TruncateWithoutTooltip } from './truncate_with_tooltip';
+import { TruncateWithoutTooltip } from './truncate_without_tooltip';
 
 const StyledLink = euiStyled(EuiLink)`min-width: 0;`;
 

--- a/x-pack/plugins/apm/public/components/shared/truncate_without_tooltip/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/truncate_without_tooltip/index.tsx
@@ -10,16 +10,6 @@ import React from 'react';
 import { euiStyled } from '../../../../../../../src/plugins/kibana_react/common';
 import { truncate } from '../../../utils/style';
 
-const tooltipAnchorClassname = '_apm_truncate_tooltip_anchor_';
-
-const TooltipWrapper = euiStyled.div`
-  width: 100%;
-  .${tooltipAnchorClassname} {
-    width: 100% !important;
-    display: block !important;
-  }
-`;
-
 const ContentWrapper = euiStyled.div`
   ${truncate('100%')}
 `;
@@ -30,18 +20,8 @@ interface Props {
   'data-test-subj'?: string;
 }
 
-export function TruncateWithTooltip(props: Props) {
+export function TruncateWithoutTooltip(props: Props) {
   const { text, content, ...rest } = props;
 
-  return (
-    <TooltipWrapper {...rest}>
-      <EuiToolTip
-        delay="long"
-        content={text}
-        anchorClassName={tooltipAnchorClassname}
-      >
-        <ContentWrapper>{content || text}</ContentWrapper>
-      </EuiToolTip>
-    </TooltipWrapper>
-  );
+  return <ContentWrapper>{content || text}</ContentWrapper>;
 }


### PR DESCRIPTION
## Summary

This PR will resolve ellipsis truncation issue which is mentioned https://github.com/elastic/kibana/issues/112976 The following screenshots clearly show that the ellipsis has been applied on dependency and service name section.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
